### PR TITLE
More universal data path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ if 'install' in sys.argv:
     repository_dir = os.path.dirname(os.path.realpath(__file__))
 
     # We need a moog data directory
-    data_dir = os.path.expanduser('~/.moog')
+    data_dir = os.path.expanduser('/.moog')
     if not os.path.exists(data_dir):
         system_call('mkdir %s' % data_dir)
 


### PR DESCRIPTION
The ~/.moog directory is hard-coded into the binary during compilation. This means that the binary can only be run by a single user on a single machine. By adjusting the path to /.moog, this makes the binaries cross-user and corss-machine, as this folder can exist and be read by anyone.
